### PR TITLE
Fix and generalize

### DIFF
--- a/{{cookiecutter.slug}}/README.md
+++ b/{{cookiecutter.slug}}/README.md
@@ -13,7 +13,7 @@ Installation
 To install from Github, you only need the `src` directory.
 
 ```bash
-git clone git@github.com:Presslabs/{{cookiecutter.slug}}
+git clone {{cookiecutter.git_url}}
 cd {{cookiecutter.slug}}
 cp -r src /path/to/site/wp-content/plugins/{{cookiecutter.slug}}
 ```

--- a/{{cookiecutter.slug}}/src/readme.txt
+++ b/{{cookiecutter.slug}}/src/readme.txt
@@ -11,8 +11,8 @@ License URI: {{cookiecutter.license_url}}
 
 {{cookiecutter.description}}
 
-= Github repository =
-https://github.com/presslabs/{{cookiecutter.slug}}
+= Git repository =
+{{cookiecutter.git_url}}
 
 == Changelog ==
 

--- a/{{cookiecutter.slug}}/src/readme.txt
+++ b/{{cookiecutter.slug}}/src/readme.txt
@@ -2,7 +2,7 @@
 Contributors: {{cookiecutter.author}}
 Donate link: {{cookiecutter.author_url}}
 Requires at least: {{cookiecutter.requires_at_least}}
-Tested up to: {{cookiecutter.test_up_to}}
+Tested up to: {{cookiecutter.tested_up_to}}
 License: {{cookiecutter.license_name}}
 License URI: {{cookiecutter.license_url}}
 


### PR DESCRIPTION
Hi!

The first commit rightens typo on dict attirbute {{cookiecutter.tested_up_to}}.
The second one aims to generalize Git repo reference.

Hope that help!